### PR TITLE
Background search threading fixes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,6 @@
 platform :ios, '8.0'
 
 target 'ThreadingSample' do
-  pod 'BRFullTextSearch', '~> 1.0.10'
+	pod 'BRFullTextSearch', :git => 'https://github.com/Blue-Rocket/BRFullTextSearch.git', :branch => 'feature/searcher-threading', :submodules => true
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,33 +1,45 @@
 PODS:
-  - BRFullTextSearch (1.0.10):
-    - BRFullTextSearch/Core (= 1.0.10)
-  - BRFullTextSearch/API (1.0.10)
-  - BRFullTextSearch/CLucene (1.0.10):
+  - BRFullTextSearch (1.1.0):
+    - BRFullTextSearch/Core (= 1.1.0)
+  - BRFullTextSearch/API (1.1.0)
+  - BRFullTextSearch/CLucene (1.1.0):
     - BRFullTextSearch/CLucene-Contribs-Lib
     - BRFullTextSearch/CLucene-Core
     - BRFullTextSearch/CLucene-Shared
-  - BRFullTextSearch/CLucene-Config (1.0.10)
-  - BRFullTextSearch/CLucene-Contribs-Lib (1.0.10):
+  - BRFullTextSearch/CLucene-Config (1.1.0)
+  - BRFullTextSearch/CLucene-Contribs-Lib (1.1.0):
     - BRFullTextSearch/CLucene-Core
     - BRFullTextSearch/CLucene-Shared
-  - BRFullTextSearch/CLucene-Core (1.0.10):
+  - BRFullTextSearch/CLucene-Core (1.1.0):
     - BRFullTextSearch/CLucene-Core-API
     - BRFullTextSearch/CLucene-Shared
-  - BRFullTextSearch/CLucene-Core-API (1.0.10):
+  - BRFullTextSearch/CLucene-Core-API (1.1.0):
     - BRFullTextSearch/CLucene-Config
-  - BRFullTextSearch/CLucene-Shared (1.0.10):
+  - BRFullTextSearch/CLucene-Shared (1.1.0):
     - BRFullTextSearch/CLucene-Core-API
-  - BRFullTextSearch/Core (1.0.10):
+  - BRFullTextSearch/Core (1.1.0):
     - BRFullTextSearch/API
     - BRFullTextSearch/Implementation-CLucene
-  - BRFullTextSearch/Implementation-CLucene (1.0.10):
+  - BRFullTextSearch/Implementation-CLucene (1.1.0):
     - BRFullTextSearch/API
     - BRFullTextSearch/CLucene
 
 DEPENDENCIES:
-  - BRFullTextSearch (~> 1.0.10)
+  - BRFullTextSearch (from `https://github.com/Blue-Rocket/BRFullTextSearch.git`,
+    branch `feature/searcher-threading`)
+
+EXTERNAL SOURCES:
+  BRFullTextSearch:
+    :branch: feature/searcher-threading
+    :git: https://github.com/Blue-Rocket/BRFullTextSearch.git
+    :submodules: true
+
+CHECKOUT OPTIONS:
+  BRFullTextSearch:
+    :commit: bd9733ca4f3e655922189bfe107d6e4ad95fdf15
+    :git: https://github.com/Blue-Rocket/BRFullTextSearch.git
 
 SPEC CHECKSUMS:
-  BRFullTextSearch: 11eb51d09423cfbdab713ec3fbb221ad36e66239
+  BRFullTextSearch: d865ee81c77daece2fa1dd25bad951de5290b848
 
 COCOAPODS: 0.39.0

--- a/ThreadingSample/ViewController.m
+++ b/ThreadingSample/ViewController.m
@@ -104,7 +104,9 @@
     for (int i = lo; i < hi; i++) {
         NSDictionary<NSString *, NSString *> *doc = [self.data objectAtIndex:i];
         NSString *identifier = doc[kBRSearchFieldNameIdentifier];
-        self.numberOfPendingOperations++;
+		dispatch_sync(self.indexQueue, ^{
+			self.numberOfPendingOperations++;
+		});
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
             dispatch_async(self.indexQueue, ^{
                 __strong ViewController *strongSelf = weakSelf;
@@ -125,7 +127,9 @@
         NSMutableDictionary<NSString *, NSString *> *doc = [NSMutableDictionary dictionaryWithDictionary:[self.data objectAtIndex:i]];
         NSString *identifier = doc[kBRSearchFieldNameIdentifier];
         [doc removeObjectForKey:kBRSearchFieldNameIdentifier];
-        self.numberOfPendingOperations++;
+		dispatch_sync(self.indexQueue, ^{
+			self.numberOfPendingOperations++;
+		});
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
             dispatch_async(self.indexQueue, ^{
                 __strong ViewController *strongSelf = weakSelf;


### PR DESCRIPTION
I've created a **feature/searcher-threading** branch in BRFullTextSearch with what I think are some fixes that address your issues (which arose from an assumption that searches were executed on the main thread) and then switched your sample project to use that for the Pod. At this point when I ran the sample project now it no longer crashed, however I noticed that due to the very frequent and high number of thread accesses to Lucene that eventually Lucene would throw a "too many open files" exception.

Then I noticed some mutation of the `numberOfPendingOperations` ivar happening concurrently and tweaked `ViewController` to not do that, and after this point the sample project runs without throwing the "too many open files" exception.

I should note that the use of threads in this sample seems a bit unusual to me. It would be more common to see searches executed on the main thread and the results used to immediately update the UI with the results. The expectation is that searches should be fast enough to complete on the main thread, and running them in the background probably doesn't gain responsiveness overall.

Finally, I noticed in the `searchFor:` method the `results` instance is created in one thread, but then passed it to the main thread to be used there. It does seem to work, but I think it would be safer to _not_ pass Lucene objects across thread boundaries like that. Instead you could either 
1. execute the search on the main thread in the first place as discussed previously or
2. copy all the information you need from the results on the same thread you executed the search on and pass the copies to the main thread

In any event, your sample project has been very useful for inspecting how BRFullTextSearch reacts to a high number of concurrent threads. Thank you for putting it together!
